### PR TITLE
Migrere til Aiven Kafka

### DIFF
--- a/nais/dev-fss.json
+++ b/nais/dev-fss.json
@@ -5,6 +5,7 @@
   "team": "dusseldorf",
   "tenant" : "trygdeetaten.no",
   "omsorgspengerutbetaling-api-cluster" : "dev-gcp",
+  "kafka-pool" : "nav-dev",
   "minReplicas": "1",
   "maxReplicas": "2",
   "ingresses": [
@@ -14,8 +15,7 @@
   "env": {
     "K9_DOKUMENT_BASE_URL": "https://k9-dokument.nais.preprod.local",
     "AZURE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/.well-known/openid-configuration",
-    "LAGRE_DOKUMENT_SCOPES": "97f0b1bc-6aa9-4d44-a3c7-60b4318fbec4/.default",
-    "KAFKA_BOOTSTRAP_SERVERS": "b27apvl00045.preprod.local:8443,b27apvl00046.preprod.local:8443,b27apvl00047.preprod.local:8443"
+    "LAGRE_DOKUMENT_SCOPES": "97f0b1bc-6aa9-4d44-a3c7-60b4318fbec4/.default"
   },
   "slack-channel": "sif-alerts-dev",
   "slack-notify-type": "<!here> | omsorgspengerutbetalingsoknad-mottak | ",

--- a/nais/naiserator.yml
+++ b/nais/naiserator.yml
@@ -11,6 +11,8 @@ spec:
     application:
       enabled: true
       tenant: {{tenant}}
+  kafka:
+    pool: {{kafka-pool}}
   accessPolicy:
     inbound:
       rules:

--- a/nais/naiserator.yml
+++ b/nais/naiserator.yml
@@ -48,8 +48,6 @@ spec:
   prometheus:
     enabled: true
     path: /metrics
-  envFrom:
-    - secret: {{app}}
   webproxy: true
   env:
   {{#each env}}

--- a/nais/prod-fss.json
+++ b/nais/prod-fss.json
@@ -5,6 +5,7 @@
   "team": "dusseldorf",
   "tenant" : "nav.no",
   "omsorgspengerutbetaling-api-cluster" : "prod-gcp",
+  "kafka-pool" : "nav-prod",
   "minReplicas": "1",
   "maxReplicas": "2",
   "ingresses": [
@@ -14,8 +15,7 @@
   "env": {
     "K9_DOKUMENT_BASE_URL": "https://k9-dokument.nais.adeo.no",
     "AZURE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/62366534-1ec3-4962-8869-9b5535279d0b/.well-known/openid-configuration",
-    "LAGRE_DOKUMENT_SCOPES": "0c5a6709-ba2a-42b7-bbfc-9b9f844e2ee2/.default",
-    "KAFKA_BOOTSTRAP_SERVERS": "a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443"
+    "LAGRE_DOKUMENT_SCOPES": "0c5a6709-ba2a-42b7-bbfc-9b9f844e2ee2/.default"
   },
   "slack-channel": "sif-alerts",
   "slack-notify-type": "<!channel> | omsorgspengerutbetalingsoknad-mottak | ",

--- a/src/main/kotlin/no/nav/helse/Configuration.kt
+++ b/src/main/kotlin/no/nav/helse/Configuration.kt
@@ -1,15 +1,14 @@
 package no.nav.helse
 
-import io.ktor.config.ApplicationConfig
-import io.ktor.util.KtorExperimentalAPI
-import no.nav.helse.dusseldorf.ktor.auth.*
+import io.ktor.config.*
+import no.nav.helse.dusseldorf.ktor.auth.issuers
+import no.nav.helse.dusseldorf.ktor.auth.withoutAdditionalClaimRules
 import no.nav.helse.dusseldorf.ktor.core.getOptionalString
 import no.nav.helse.dusseldorf.ktor.core.getRequiredList
 import no.nav.helse.dusseldorf.ktor.core.getRequiredString
 import no.nav.helse.kafka.KafkaConfig
 import java.net.URI
 
-@KtorExperimentalAPI
 data class Configuration(private val config : ApplicationConfig) {
 
     private val issuers = config.issuers()
@@ -21,16 +20,22 @@ data class Configuration(private val config : ApplicationConfig) {
     internal fun issuers() = issuers.withoutAdditionalClaimRules()
     internal fun getK9DokumentBaseUrl() = URI(config.getRequiredString("nav.k9_dokument_base_url", secret = false))
     internal fun getKafkaConfig() = config.getRequiredString("nav.kafka.bootstrap_servers", secret = false).let { bootstrapServers ->
-        val trustStore = config.getOptionalString("nav.trust_store.path", secret = false)?.let { trustStorePath ->
-            config.getOptionalString("nav.trust_store.password", secret = true)?.let { trustStorePassword ->
-                Pair(trustStorePath, trustStorePassword)
+        val trustStore = config.getOptionalString("nav.kafka.truststore_path", secret = false)?.let { trustStorePath ->
+            config.getOptionalString("nav.kafka.credstore_password", secret = true)?.let { credstorePassword ->
+                Pair(trustStorePath, credstorePassword)
+            }
+        }
+
+        val keyStore = config.getOptionalString("nav.kafka.keystore_path", secret = false)?.let { keystorePath ->
+            config.getOptionalString("nav.kafka.credstore_password", secret = true)?.let { credstorePassword ->
+                Pair(keystorePath, credstorePassword)
             }
         }
 
         KafkaConfig(
             bootstrapServers = bootstrapServers,
-            credentials = Pair(config.getRequiredString("nav.kafka.username", secret = false), config.getRequiredString("nav.kafka.password", secret = true)),
-            trustStore = trustStore
+            trustStore = trustStore,
+            keyStore = keyStore
         )
     }
 

--- a/src/main/kotlin/no/nav/helse/OmsorgspengerutbetalingsoknadMottak.kt
+++ b/src/main/kotlin/no/nav/helse/OmsorgspengerutbetalingsoknadMottak.kt
@@ -1,20 +1,15 @@
 package no.nav.helse
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.PropertyNamingStrategy
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.ktor.application.*
-import io.ktor.auth.Authentication
-import io.ktor.auth.authenticate
-import io.ktor.features.CallId
-import io.ktor.features.CallLogging
-import io.ktor.features.ContentNegotiation
-import io.ktor.features.StatusPages
-import io.ktor.jackson.jackson
-import io.ktor.metrics.micrometer.MicrometerMetrics
-import io.ktor.routing.Routing
-import io.ktor.util.AttributeKey
-import io.ktor.util.KtorExperimentalAPI
+import io.ktor.auth.*
+import io.ktor.features.*
+import io.ktor.jackson.*
+import io.ktor.metrics.micrometer.*
+import io.ktor.routing.*
+import io.ktor.util.*
 import io.prometheus.client.hotspot.DefaultExports
 import no.nav.helse.auth.AccessTokenClientResolver
 import no.nav.helse.dokument.DokumentGateway
@@ -42,7 +37,6 @@ private val soknadIdAttributeKey = AttributeKey<String>(soknadIdKey)
 
 fun main(args: Array<String>): Unit = io.ktor.server.netty.EngineMain.main(args)
 
-@KtorExperimentalAPI
 fun Application.omsorgspengerutbetalingsoknadMottak() {
     val appId = environment.config.id()
     logProxyProperties()
@@ -137,5 +131,5 @@ private fun ApplicationCall.setSoknadItAsAttributeAndGet(): String {
 internal fun ApplicationCall.getSoknadId() = SoknadId(attributes[soknadIdAttributeKey])
 
 internal fun k9DokumentKonfigurert() : ObjectMapper = jacksonObjectMapper().dusseldorfConfigured().apply {
-    propertyNamingStrategy = PropertyNamingStrategy.SNAKE_CASE
+    propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE
 }

--- a/src/main/kotlin/no/nav/helse/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/helse/kafka/KafkaConfig.kt
@@ -4,23 +4,25 @@ import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.config.SaslConfigs
 import org.apache.kafka.common.config.SslConfigs
+import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.util.*
 
 private val logger: Logger = LoggerFactory.getLogger(KafkaConfig::class.java)
-private const val ID_PREFIX = "srvomsut-mottak-"
+private const val ID_PREFIX = "omsut-mottak-"
 
 internal class KafkaConfig(
     bootstrapServers: String,
-    val credentials: Pair<String, String>,
-    trustStore: Pair<String, String>?
+    trustStore: Pair<String, String>?,
+    keyStore: Pair<String, String>?
 ) {
     private val producer = Properties().apply {
         put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
-        medCredentials(credentials)
+        if(trustStore == null || keyStore == null) medCredentials(Pair("srvkafkaclient", "kafkaclient")) //For å skille mellom test/miljø
         medTrustStore(trustStore)
+        medKeyStore(keyStore)
     }
 
     internal fun producer(name: String) = producer.apply {
@@ -31,7 +33,8 @@ internal class KafkaConfig(
 private fun Properties.medTrustStore(trustStore: Pair<String, String>?) {
     trustStore?.let {
         try {
-            put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL")
+            put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "jks")
+            put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name)
             put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, File(it.first).absolutePath)
             put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, it.second)
             logger.info("Truststore på '${it.first}' konfigurert.")
@@ -43,6 +46,18 @@ private fun Properties.medTrustStore(trustStore: Pair<String, String>?) {
         }
     }
 }
+
+private fun Properties.medKeyStore(keyStore: Pair<String, String>?) {
+    keyStore?.let {
+        try {
+            put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PKCS12")
+            put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, File(it.first).absolutePath)
+            put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, it.second)
+            logger.info("Keystore på '${it.first}' konfigurert.")
+        } catch (cause: Throwable) {}
+    }
+}
+
 private fun Properties.medCredentials(credentials: Pair<String, String>) {
     put(SaslConfigs.SASL_MECHANISM, "PLAIN")
     put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT")
@@ -50,9 +65,4 @@ private fun Properties.medCredentials(credentials: Pair<String, String>) {
         SaslConfigs.SASL_JAAS_CONFIG,
         "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"${credentials.first}\" password=\"${credentials.second}\";"
     )
-}
-
-fun getEnvVar(varName: String, defaultValue: String? = null): String {
-    val varValue = System.getenv(varName) ?: defaultValue
-    return varValue ?: throw IllegalArgumentException("Variable $varName cannot be empty")
 }

--- a/src/main/kotlin/no/nav/helse/kafka/Topics.kt
+++ b/src/main/kotlin/no/nav/helse/kafka/Topics.kt
@@ -16,6 +16,5 @@ internal data class TopicUse<V>(
 }
 
 internal object Topics {
-    internal const val MOTTATT = "privat-omsorgspengerutbetalingsoknad-mottatt"
-    internal const val DITT_NAV_BESKJED = "aapen-brukernotifikasjon-nyBeskjed-v1"
+    internal const val MOTTATT = "dusseldorf.privat-omsorgspengerutbetalingsoknad-mottatt"
 }

--- a/src/main/kotlin/no/nav/helse/mottak/v1/SoknadV1KafkaProducer.kt
+++ b/src/main/kotlin/no/nav/helse/mottak/v1/SoknadV1KafkaProducer.kt
@@ -34,8 +34,8 @@ internal class SoknadV1KafkaProducer(
         TOPIC_USE.valueSerializer
     )
 
-    internal fun produce(
-        soknad: SoknadV1Outgoing,
+    internal fun produserKafkaMelding(
+        søknad: SoknadV1Outgoing,
         metadata: Metadata
     ) {
         if (metadata.version != 1) throw IllegalStateException("Kan ikke legge søknad på versjon ${metadata.version} til prosessering.")
@@ -43,10 +43,10 @@ internal class SoknadV1KafkaProducer(
         val recordMetaData = producer.send(
             ProducerRecord(
                 TOPIC_USE.name,
-                soknad.soknadId.id,
+                søknad.soknadId.id,
                 TopicEntry(
                     metadata = metadata,
-                    data = soknad.jsonObject
+                    data = søknad.jsonObject
                 )
             )
         ).get()

--- a/src/main/kotlin/no/nav/helse/mottak/v1/SoknadV1MottakService.kt
+++ b/src/main/kotlin/no/nav/helse/mottak/v1/SoknadV1MottakService.kt
@@ -1,9 +1,9 @@
 package no.nav.helse.mottak.v1
 
+import no.nav.helse.AktoerId
 import no.nav.helse.CorrelationId
 import no.nav.helse.Metadata
 import no.nav.helse.SoknadId
-import no.nav.helse.AktoerId
 import no.nav.helse.dokument.Dokument
 import no.nav.helse.dokument.DokumentGateway
 import org.slf4j.LoggerFactory
@@ -38,9 +38,9 @@ internal class SoknadV1MottakService(
             .somOutgoing()
 
         logger.info("Legger på kø")
-        soknadV1KafkaProducer.produce(
+        soknadV1KafkaProducer.produserKafkaMelding(
             metadata = metadata,
-            soknad = outgoing
+            søknad = outgoing
         )
 
         return soknadId

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -50,12 +50,13 @@ nav {
         }
     }
     kafka {
-        bootstrap_servers = ""
-        bootstrap_servers = ${?KAFKA_BOOTSTRAP_SERVERS}
-        username = ""
-        username = ${?SRV_USERNAME}
-        password = ""
-        password = ${?SRV_PASSWORD}
+        bootstrap_servers = ${?KAFKA_BROKERS}
+        truststore_path = ""
+        truststore_path = ${?KAFKA_TRUSTSTORE_PATH}
+        credstore_password = ""
+        credstore_password = ${?KAFKA_CREDSTORE_PASSWORD}
+        keystore_path = ""
+        keystore_path = ${?KAFKA_KEYSTORE_PATH}
     }
     trust_store {
         path = ""

--- a/src/test/kotlin/no/nav/helse/KafkaWrapper.kt
+++ b/src/test/kotlin/no/nav/helse/KafkaWrapper.kt
@@ -25,8 +25,7 @@ object KafkaWrapper {
             withSchemaRegistry = false,
             withSecurity = true,
             topicNames= listOf(
-                Topics.MOTTATT,
-                Topics.DITT_NAV_BESKJED
+                Topics.MOTTATT
             )
         )
         return kafkaEnvironment

--- a/src/test/kotlin/no/nav/helse/TestConfiguration.kt
+++ b/src/test/kotlin/no/nav/helse/TestConfiguration.kt
@@ -24,8 +24,6 @@ object TestConfiguration {
         // Kafka
         kafkaEnvironment?.let {
             map["nav.kafka.bootstrap_servers"] = it.brokersURL
-            map["nav.kafka.username"] = it.username()
-            map["nav.kafka.password"] = it.password()
         }
 
         // Clients


### PR DESCRIPTION
Legger til kafka.pool i naiserator slik at man henter Kafka credentials.
Fikser Kafka config til å støtte Aiven.
Fikser application.conf til å matche kafka credentials fra nais.
Fjerner gammel kode og renamer. 